### PR TITLE
Ruby 2 / pdftk2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,14 @@ A typical usecase is as follows:
 
 ## Note about this version
 
-This is a prerelease 1.0.0.rc1 version on an almost abandonned project. The main
-difference (broken API) with the 0.5.0 branch is that support for ActiveRecord 
-has been entirely removed (mostly because the implementation was ugly so far).
-If you use pdf-toolkit and would like activerecord to be included in 1.0.0, 
-please just tell us and we'll add it. If you upgrade from 0.5.0 to 1.0.0.rc1 and 
-something else goes wrong, please report the issue on github.
+Version 1.1.0 requires PDFTK version 2.0
 
 ## Contributors
 
 * Tim Pope is the original author of pdf-toolkit
 * Preston Marshall ported the project to github
 * Bernard Lambeau is the current maintainer
+* James Prior made small changes for PDFtk Server 2.0
 
 Please report issues on [github](https://github.com/blambeau/pdf-toolkit/issues)
 

--- a/lib/pdf/toolkit/native.rb
+++ b/lib/pdf/toolkit/native.rb
@@ -12,14 +12,14 @@ class PDF::Toolkit
       options = args.last.is_a?(Hash) ? args.pop : {}
       args << "dont_ask"
       args << options
-      result = call_program(:pdftk,*args,&block)
+      result = call_program("pdftk",*args,&block)
       return block_given? ? $?.success? : result
     end
 
     # Invoke +pdftotext+.  If +outfile+ is omitted, returns an +IO+ object for
     # the output.
     def pdftotext(file,outfile = nil,&block)
-      call_program(:pdftotext,file,
+      call_program("pdftotext",file,
         outfile||"-",:mode => (outfile ? nil : 'r'),&block)
     end
 


### PR DESCRIPTION
A few small changes for ruby 2 support, require pdftk-server version 2 which comes with UTF8 support, and bump the version to 1.1.0
