### PR TITLE
Bugfix: Making STDERR reopen work with mingw RUBY_PLATFORM for windows

### DIFF
--- a/lib/pdf/toolkit/native.rb
+++ b/lib/pdf/toolkit/native.rb
@@ -31,7 +31,7 @@ class PDF::Toolkit
       options[:mode] ||= 'r' if block_given?
       unless options[:silence_stderr] == false
         old_stream = STDERR.dup
-        STDERR.reopen(RUBY_PLATFORM =~ /mswin/ ? 'NUL:' : '/dev/null')
+        STDERR.reopen(RUBY_PLATFORM =~ /mswin|mingw/ ? 'NUL:' : '/dev/null')
         STDERR.sync = true
       end
       if options[:mode]


### PR DESCRIPTION
When i try to use PDF::Toolkit.pdftk command on windows, i get the error 'No such file or directory - /dev/null'
RUBY_PLATFORM = i386-mingw32 in my case
Inspired by the #4 issue